### PR TITLE
Improve <option> handling

### DIFF
--- a/node.py
+++ b/node.py
@@ -151,6 +151,14 @@ class Element(Node):
                 return
         self.children.append(Text(data))
 
+    def prepend_text(self, data):
+        if self.children:
+            first_child = self.children[0]
+            if isinstance(first_child, Text):
+                first_child.data = data + first_child.data
+                return
+        self.children.insert(0, Text(data))
+
     def add_entity(self, name):
         self.children.append(Entity(name))
 
@@ -187,14 +195,14 @@ class Entity(Node):
 # Visitor base class
 
 class Visitor:
-    def visit(self, node):
+    def visit(self, node, parent=None):
         if isinstance(node, Element):
             early_exit = self.previsit_element(node)
             if early_exit:
                 return
-            for child in node.children:
-                self.visit(child)
-            self.postvisit_element(node)
+            for child in list(node.children):
+                self.visit(child, node)
+            self.postvisit_element(node, parent)
         elif isinstance(node, Comment):
             self.visit_comment(node)
         elif isinstance(node, Text):
@@ -207,7 +215,7 @@ class Visitor:
     def previsit_element(self, element):
         raise NotImplementedError
 
-    def postvisit_element(self, element):
+    def postvisit_element(self, element, parent):
         raise NotImplementedError
 
     def visit_comment(self, comment):
@@ -223,7 +231,7 @@ class NoopVisitor(Visitor):
     def previsit_element(self, element):
         pass
 
-    def postvisit_element(self, element):
+    def postvisit_element(self, element, parent):
         pass
 
     def visit_comment(self, comment):

--- a/texi2rst.py
+++ b/texi2rst.py
@@ -1032,6 +1032,9 @@ def fixup_inline_markup(tree):
                 element.rst_kind = InlineMarkup('command')
             elif element.kind == 'var':
                 element.rst_kind = InlineMarkup('samp')
+                # wrap the variable in braces
+                element.prepend_text('{')
+                element.add_text('}')
             elif element.kind == 'code':
                 element.rst_kind = MatchedInlineMarkup('``')
             elif element.kind == 'dfn':
@@ -1677,7 +1680,7 @@ class InlineMarkupTests(Texi2RstTests):
         doc = from_xml_string(xml_src)
         doc = fixup_inline_markup(doc)
         out = self.make_rst_string(doc)
-        self.assertEqual(u'Before :samp:`gcc` after', out)
+        self.assertEqual(u'Before :samp:`{gcc}` after', out)
 
     def test_code(self):
         xml_src = '<texinfo>Before <code>gcc</code> after</texinfo>'
@@ -1747,14 +1750,14 @@ some chapter text
         doc = from_xml_string(xml_src)
         doc = convert_to_rst(doc, self.ctxt)
         out = self.make_rst_string(doc)
-        self.assertEqual('This is similar to how :option:`-Walloca-larger-than`:samp:`=byte-size` works.\n\n', out)
+        self.assertEqual('This is similar to how :option:`-Walloca-larger-than`:samp:`={byte-size}` works.\n\n', out)
 
     def test_option_ref_with_var2(self):
         xml_src = '<para>See also <option>-Walloca-larger-than=<var>byte-size</var></option>.</para>'
         doc = from_xml_string(xml_src)
         doc = convert_to_rst(doc, self.ctxt)
         out = self.make_rst_string(doc)
-        self.assertEqual('See also :option:`-Walloca-larger-than`:samp:`=byte-size`.\n\n', out)
+        self.assertEqual('See also :option:`-Walloca-larger-than`:samp:`={byte-size}`.\n\n', out)
 
 class OptionTests(Texi2RstTests):
     def test_valid_option_ref(self):
@@ -1930,7 +1933,7 @@ types.)
         doc = from_xml_string(xml_src)
         doc = convert_to_rst(doc, self.ctxt)
         out = self.make_rst_string(doc)
-        self.assertEqual(':option:`-Walloca-larger-than`:samp:`=byte-size`', out)
+        self.assertEqual(':option:`-Walloca-larger-than`:samp:`={byte-size}`', out)
 
 class TableEntryTests(Texi2RstTests):
     def test_generating_definition_list(self):

--- a/texi2rst.py
+++ b/texi2rst.py
@@ -854,6 +854,8 @@ def fixup_examples(tree):
         def handle_option_listing(self, element, pre):
             class OptionWrappingVisitor(NoopVisitor):
                 def postvisit_element(self, element, parent):
+                    if element.kind == 'var':
+                        return
                     new_children = []
                     for child in element.children:
                         if isinstance(child, Text):
@@ -1919,6 +1921,16 @@ types.)
 
 ''',
             out)
+
+    def test_option_listing_with_vars(self):
+        xml_src = ('''
+<smallexample endspaces=" ">
+<pre xml:space="preserve">-Walloca-larger-than=<var>byte-size</var></pre></smallexample>
+''')
+        doc = from_xml_string(xml_src)
+        doc = convert_to_rst(doc, self.ctxt)
+        out = self.make_rst_string(doc)
+        self.assertEqual(':option:`-Walloca-larger-than`:samp:`=byte-size`', out)
 
 class TableEntryTests(Texi2RstTests):
     def test_generating_definition_list(self):


### PR DESCRIPTION
In order to have a working `:option:` link, one needs to remove `=@{var}` part and have a corresponding space around an `option` or `var` elements.